### PR TITLE
Integration test fix

### DIFF
--- a/routers/web/admin/auths.go
+++ b/routers/web/admin/auths.go
@@ -270,6 +270,14 @@ func parseSAMLConfig(ctx *context.Context, form forms.AuthenticationForm) (*saml
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		privateKey, cert, err := saml.GenerateSAMLSPKeypair()
+		if err != nil {
+			return nil, err
+		}
+
+		form.ServiceProviderPrivateKey = privateKey
+		form.ServiceProviderCertificate = cert
 	}
 
 	return &saml.Source{


### PR DESCRIPTION
As far as I can tell, SimpleSAMLPhp requires that a SAML signing certificate for a given SP must be [configured](https://github.com/simplesamlphp/simplesamlphp/blob/120a1002ccfff2484543a03fec94105533fecdb4/modules/saml/src/Message.php#L164) rather than provided in the metadata that the SP publishes. It doesn't seem like something that is part of the SAML standard. Therefore, testing SAML request signing with the SimpleSAMLPhp server would require hard coding a private key in the integration test and a X509 certificate in the SimpleSAMLPhp server configuration.

## Changes
- Autogenerate a cert/private key if omitted in configuration.
- Change signing flag to depend on the presence of cert/private key
